### PR TITLE
Link minimapSize to width instead of height

### DIFF
--- a/MinimapGUI.cs
+++ b/MinimapGUI.cs
@@ -339,7 +339,7 @@ namespace LethalCompanyMinimap.Component
 
                         if (LeftClickButton(new Rect(guiCenterX, guiYpos + 440, ITEMWIDTH, 30), "Reset to Default Size"))
                         {
-                            minimapSize = 150;
+                            minimapSize = 200;
                         }
                         if (LeftClickButton(new Rect(guiCenterX, guiYpos + 480, ITEMWIDTH, 30), "Reset to Default Position"))
                         {

--- a/Patches/PlayerControllerBPatch.cs
+++ b/Patches/PlayerControllerBPatch.cs
@@ -15,7 +15,7 @@ namespace LethalCompanyMinimap.Patches
     internal class PlayerControllerBPatch
     {
         private const int padding = -5;
-        private const float aspectRatio = (4f / 3f); // Aspect ratio of the ship monitor (4:3)
+        private const float aspectRatio = (13f / 9f); // Aspect ratio of the ship monitor (13:9)
         private static GameObject minimapObj;
         private static RawImage minimap;
         private static RectTransform tooltips;

--- a/Patches/PlayerControllerBPatch.cs
+++ b/Patches/PlayerControllerBPatch.cs
@@ -43,8 +43,8 @@ namespace LethalCompanyMinimap.Patches
             }
 
             // Get the Minimap size from the settings
-            int height = MinimapMod.minimapGUI.minimapSize;
-            int width = (int)(height * aspectRatio);
+            int width = MinimapMod.minimapGUI.minimapSize;
+            int height = (int)(width / aspectRatio);
 
             // Check if we have a Minimap yet
             if (minimap == null || minimapObj == null)
@@ -127,8 +127,8 @@ namespace LethalCompanyMinimap.Patches
                 // Resize Minimap
                 if (MinimapMod.minimapGUI.minimapSize != minimap.rectTransform.sizeDelta.y)
                 {
-                    int height = MinimapMod.minimapGUI.minimapSize;
-                    int width = (int)(height * aspectRatio);
+                    int width = MinimapMod.minimapGUI.minimapSize;
+                    int height = (int)(width / aspectRatio);
                     minimap.rectTransform.sizeDelta = new Vector2(width, height);
                     tooltips.anchoredPosition = tooltipsOriginalPos - new Vector2(0, height);
                 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -26,7 +26,7 @@ namespace LethalCompanyMinimap
         public static MouseAndKeyboard defaultToggleMinimapKey = MouseAndKeyboard.F2;
         public static MouseAndKeyboard defaultToggleOverrideKey = MouseAndKeyboard.F3;
         public static MouseAndKeyboard defaultSwitchTargetKey = MouseAndKeyboard.F4;
-        public const int defaultMinimapSize = 150;
+        public const int defaultMinimapSize = 200;
         public const float defaultXoffset = 0f;
         public const float defaultYoffset = 0f;
         public const float defaultMapZoom = 19.7f;


### PR DESCRIPTION
This will ensure the width stays identical post-update for users who have a pre-existing config file, shrinking the height instead.

I also changed the aspect ratio to 13:9, as this is the exact ratio to obtain perfect circles on the minimap. The ship screen is actually 5:4, which itself is therefore incorrect too...